### PR TITLE
Add .mversionrc for easier releases

### DIFF
--- a/.mversionrc
+++ b/.mversionrc
@@ -1,0 +1,10 @@
+{
+  "commitMessage": "%s",
+  "tagName": "v%s",
+  "scripts": {
+    "preupdate": "echo 'Bumping version and running tests'",
+    "precommit": "npm test",
+    "postcommit": "git push && git push --tags && npm publish",
+    "postupdate": "echo 'Updated to version %s in manifest files'"
+  }
+}

--- a/README.md
+++ b/README.md
@@ -5,3 +5,22 @@ ccb-node
 
 A lightweight wrapper for the Church Community Builder API
 
+# Releasing
+
+Use [mversion](https://www.npmjs.com/package/mversion) to easily release a new version.
+
+```shell
+npm i -g mversion
+
+# mversion [ major | minor | patch ]
+mversion minor
+```
+
+This will:
+
+- run the tests
+- update `package.json`
+- add a commit and git tag
+- push the current branch
+- push git tags
+- release on NPM


### PR DESCRIPTION
This adds an `.mversionrc` and instructions for using mversion.  I've used Mversion in the past and like it, but i'm not dead set on using it if y'all prefer something else.
